### PR TITLE
Parse freeswitch event body

### DIFF
--- a/lib/event_socket_outbound/protocol.ex
+++ b/lib/event_socket_outbound/protocol.ex
@@ -317,16 +317,16 @@ defmodule EventSocketOutbound.Protocol do
     end
   end
 
-  defp parse_body(data, acc) do
-    if body_length = Map.get(acc, "Content-Length") do
-      body_length = :erlang.binary_to_integer(body_length)
-      <<body::binary-size(body_length), _::binary>> = data
-      Map.put(acc, :body, body)
-      |> Map.delete("Content-Length")
-      |> Map.put(:body_length, body_length)
-    else
-      acc
-    end
+  defp parse_body(data, %{"Content-Length" => body_length} = acc) do
+    body_length = :erlang.binary_to_integer(body_length)
+    <<body::binary-size(body_length), _::binary>> = data
+    Map.put(acc, :body, body)
+    |> Map.delete("Content-Length")
+    |> Map.put(:body_length, body_length)
+  end
+
+  defp parse_body(_data, acc) do
+    acc
   end
 
   defp parse_value(value, decode_value) do

--- a/lib/event_socket_outbound/protocol.ex
+++ b/lib/event_socket_outbound/protocol.ex
@@ -268,7 +268,7 @@ defmodule EventSocketOutbound.Protocol do
        ) do
     case String.length(rest) >= content_length do
       true ->
-        {event_content, new_rest} = String.split_at(rest, content_length)
+        <<event_content::binary-size(content_length), new_rest::binary>> = rest
         event = parse_event(header, event_content)
         new_state = event_cb(event, state)
         parse_buffer(new_state, new_rest)
@@ -320,7 +320,7 @@ defmodule EventSocketOutbound.Protocol do
   defp parse_body(data, acc) do
     if body_length = Map.get(acc, "Content-Length") do
       body_length = :erlang.binary_to_integer(body_length)
-      {body, _} = String.split_at(data, body_length)
+      <<body::binary-size(body_length), _::binary>> = data
       Map.put(acc, :body, body)
       |> Map.delete("Content-Length")
       |> Map.put(:body_length, body_length)

--- a/lib/event_socket_outbound/protocol.ex
+++ b/lib/event_socket_outbound/protocol.ex
@@ -249,7 +249,7 @@ defmodule EventSocketOutbound.Protocol do
 
           false ->
             decode_value = is_channel_data_event?(data)
-            event = parse_key_value(data, decode_value)
+            event = parse_map(data, decode_value)
             new_state = event_cb(event, state)
             parse_buffer(new_state, rest)
         end
@@ -268,8 +268,8 @@ defmodule EventSocketOutbound.Protocol do
        ) do
     case String.length(rest) >= content_length do
       true ->
-        {event_body, new_rest} = String.split_at(rest, content_length)
-        event = parse_event(header, event_body)
+        {event_content, new_rest} = String.split_at(rest, content_length)
+        event = parse_event(header, event_content)
         new_state = event_cb(event, state)
         parse_buffer(new_state, new_rest)
 
@@ -285,36 +285,48 @@ defmodule EventSocketOutbound.Protocol do
     end
   end
 
-  defp parse_event(data, body) do
+  defp parse_event(data, content) do
     case String.contains?(data, ["text/disconnect-notice", "api/response"]) do
       true ->
-        header_map = parse_key_value(data)
-        body_map = parse_rawdata(body)
+        header_map = parse_map(data)
+        body_map = parse_rawdata(content)
         Map.merge(header_map, body_map)
 
       false ->
-        header_map = parse_key_value(data)
-        body_map = parse_key_value(body)
+        header_map = parse_map(data)
+        body_map = parse_map(content)
         Map.merge(header_map, body_map)
     end
   end
 
-  defp parse_key_value(data, decode_value \\ true) do
-    values =
-      data
-      |> String.trim()
-      |> String.replace(" ", "")
-      |> String.split("\n")
+  defp parse_map(data, decode_value \\ true, acc \\ %{}) do
+    case String.split(data, "\n", parts: 2) do
+      [""] -> acc
+      [key_value] -> parse_key_value(key_value, decode_value, acc)
+      ["", body] -> parse_body(body, acc)
+      [key_value, rest] ->
+        acc = parse_key_value(key_value, decode_value, acc)
+        parse_map(rest, decode_value, acc)
+    end
+  end
 
-    Enum.reduce(values, %{}, fn v, acc ->
-      case String.split(v, ":") do
-        [key, value] ->
-          Map.put(acc, key, parse_value(value, decode_value))
+  defp parse_key_value(key_value, decode_value, acc) do
+    case String.split(key_value, ": ") do
+      [key, value] -> Map.put(acc, key, parse_value(value, decode_value))
+      _ -> acc
+    end
+  end
 
-        _ ->
-          acc
-      end
-    end)
+  defp parse_body(data, acc) do
+    if body_length = Map.get(acc, "Content-Length") do
+      body_length = :erlang.binary_to_integer(body_length)
+      {body, _} = String.split_at(data, body_length)
+      Map.put(acc, :body, body)
+      |> Map.delete("Content-Length")
+      |> Map.put(:body_length, body_length)
+    else
+      acc
+    end
   end
 
   defp parse_value(value, decode_value) do

--- a/test/event_socket_outbound_test.exs
+++ b/test/event_socket_outbound_test.exs
@@ -415,6 +415,12 @@ defmodule EventSocketOutbound.Test do
       assert_receive %{event: %{body_length: 421}}, 5000
     end
 
+    test "parse events containing utf8 characters" do
+      load_call_mgt_module()
+      conn_pid = start_protocol_server()
+      send(conn_pid, {:tcp, "socket", SoftswitchEvent.event_with_utf8_body()})
+      assert_receive %{event: %{body: "ࠀࠀࠀ"}}, 5000
+    end
   end
 
   defp start_protocol_server do

--- a/test/event_socket_outbound_test.exs
+++ b/test/event_socket_outbound_test.exs
@@ -398,6 +398,25 @@ defmodule EventSocketOutbound.Test do
     end
   end
 
+  describe "events with header, key-value and body" do
+    test "parse background job event" do
+      load_call_mgt_module()
+      conn_pid = start_protocol_server()
+      send(conn_pid, {:tcp, "socket", SoftswitchEvent.background_job_with_body()})
+      assert_receive %{event: %{body: "+OK 7f4de4bc-17d7-11dd-b7a0-db4edd065621\n"}}, 5000
+    end
+
+    test "parse speech detection event" do
+      load_call_mgt_module()
+      conn_pid = start_protocol_server()
+      send(conn_pid, {:tcp, "socket", SoftswitchEvent.speech_detection_with_body_part1()})
+      send(conn_pid, {:tcp, "socket", SoftswitchEvent.speech_detection_with_body_part2()})
+      send(conn_pid, {:tcp, "socket", SoftswitchEvent.speech_detection_with_body_part3()})
+      assert_receive %{event: %{body_length: 421}}, 5000
+    end
+
+  end
+
   defp start_protocol_server do
     {:ok, conn_pid} =
       EventProtocol.start_link(

--- a/test/support/fs_events.ex
+++ b/test/support/fs_events.ex
@@ -706,4 +706,20 @@ defmodule EventSocketOutbound.Test.Support.SoftswitchEvent do
     </result>
     """
   end
+
+  def event_with_utf8_body do
+    """
+    Content-Length: 28
+    Content-Type: text/event-plain
+
+    Content-Length: 9
+
+    ࠀࠀࠀ
+    Content-Length: 19
+    Content-Type: text/event-plain
+
+    Content-Length: 0
+
+    """
+  end
 end

--- a/test/support/fs_events.ex
+++ b/test/support/fs_events.ex
@@ -640,4 +640,70 @@ defmodule EventSocketOutbound.Test.Support.SoftswitchEvent do
 
     """
   end
+
+  def background_job_with_body do
+    """
+    Content-Length: 583
+    Content-Type: text/event-plain
+
+    Job-UUID: 7f4db78a-17d7-11dd-b7a0-db4edd065621
+    Job-Command: originate
+    Job-Command-Arg: sofia/default/1005%20'%26park'
+    Event-Name: BACKGROUND_JOB
+    Core-UUID: 42bdf272-16e6-11dd-b7a0-db4edd065621
+    FreeSWITCH-Hostname: ser
+    FreeSWITCH-IPv4: 192.168.1.104
+    FreeSWITCH-IPv6: 127.0.0.1
+    Event-Date-Local: 2008-05-02%2007%3A37%3A03
+    Event-Date-GMT: Thu,%2001%20May%202008%2023%3A37%3A03%20GMT
+    Event-Date-timestamp: 1209685023894968
+    Event-Calling-File: mod_event_socket.c
+    Event-Calling-Function: api_exec
+    Event-Calling-Line-Number: 609
+    Content-Length: 41
+
+    +OK 7f4de4bc-17d7-11dd-b7a0-db4edd065621
+    """
+  end
+
+  def speech_detection_with_body_part1 do
+    """
+    Content-Length: 860
+    Content-Type: text/event-plain
+
+    Speech-Type: detected-speech
+    Event-Name: DETECTED_SPEECH
+    Core-UUID: aac0f73e-b822-e54c-a02a-06a839ca3e5a
+    FreeSWITCH-Hostname: AMONROY
+    FreeSWITCH-IPv4: 192.168.1.220
+    FreeSWITCH-IPv6: ::1
+    Event-Date-Local: 2009-01-26 16:07:24
+    Event-Date-GMT: Mon, 26 Jan 2009 22:07:24 GMT
+    Event-Date-Timestamp: 1233007644906250
+    Event-Calling-File: switch_ivr_async.c
+    """
+  end
+
+  def speech_detection_with_body_part2 do
+    """
+    Event-Calling-Function: speech_thread
+    Event-Calling-Line-Number: 1758
+    Content-Length: 421
+
+    <result grammar="<request1@form-level.store>#nombres">
+        <interpretation grammar="<request1@form-level.store>#nombres" confidence="0.494643">
+            <instance confidence="0.494643">arturo monroy</instance>
+            <input mode="speech" confidence="0.494643">\
+    """
+  end
+
+  def speech_detection_with_body_part3 do
+    """
+                <input confidence="0.313102">arturo</input>
+                <input confidence="0.618854">monroy</input>
+            </input>
+        </interpretation>
+    </result>
+    """
+  end
 end


### PR DESCRIPTION
Fs event may also have a body content not in key-value format, as specified by https://freeswitch.org/confluence/display/FREESWITCH/mod_event_socket.

Event body is currently ignored by this library. this MR add support for parsing events with body.
The resulting map will have two new fields:

```elixir
%{
    body: "content",
    body_length: 7,
}
```