### PR TITLE
Fix maybe_event_is_complete not considering utf8 characters

### DIFF
--- a/lib/event_socket_outbound/protocol.ex
+++ b/lib/event_socket_outbound/protocol.ex
@@ -265,7 +265,7 @@ defmodule EventSocketOutbound.Protocol do
          rest,
          content_length
        ) do
-    case String.length(rest) >= content_length do
+    case byte_size(rest) >= content_length do
       true ->
         <<event_content::binary-size(content_length), new_rest::binary>> = rest
         event = parse_event(header, event_content)

--- a/test/support/fs_events.ex
+++ b/test/support/fs_events.ex
@@ -715,11 +715,6 @@ defmodule EventSocketOutbound.Test.Support.SoftswitchEvent do
     Content-Length: 9
 
     ࠀࠀࠀ
-    Content-Length: 19
-    Content-Type: text/event-plain
-
-    Content-Length: 0
-
     """
   end
 end


### PR DESCRIPTION
maybe_event_is_complete uses `String.length` wich counts the number of characters, not bytes. this PR uses `bytes_size` to fix this issue